### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/TheJonsey-Servers/NodeMC-CORE.png?label=ready&title=Ready)](https://waffle.io/TheJonsey-Servers/NodeMC-CORE)
 # NodeMC-CORE - The_Jonsey Fork
 
 [![Build Status](http://nodemc.space:8080/job/NodeMC/badge/icon)](http://nodemc.space:8080/job/NodeMC/) [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?maxAge=2592000)](https://gitter.im/gmemstr/nodemc)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/TheJonsey-Servers/NodeMC-CORE

This was requested by a real person (user md678685) on waffle.io, we're not trying to spam you.
